### PR TITLE
chore: migrate to project settings

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,7 +2,6 @@
   "permissions": {
     "allow": [
       "Bash(uv run pytest:*)",
-      "Bash(mkdir:*)",
       "Bash(uv run pre-commit run:*)"
     ],
     "deny": []

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ Thumbs.db
 
 # Test-related
 .coverage
+
+# Selective Claude Code file exclusion
+.claude/settings.local.json
+.claude/cache/
+.claude/logs/
+.claude/sessions/


### PR DESCRIPTION
The settings got added as local settings, which were initially source controlled.

Only project settings should be included, and not all permissions should be included there.
