### PR TITLE
feat: add dependency visualization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
     "gradio>=5.0.0",
     "huggingface-hub>=0.32.4",
     "pandas>=2.0.0",
+    "plotly>=5.0.0",
     "pydantic>=2.11.5",
     "python-dotenv>=1.1.0",
     "smolagents>=1.17.0",
@@ -27,6 +28,9 @@ dev = [
     "pytest-cov>=6.1.1",
     "pytest-dotenv>=0.5.2",
 ]
+
+[tool.uv]
+package = true
 
 [tool.uv.sources]
 en-core-web-lg = { url = "https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl" }

--- a/src/recipe_board/agents/graph_tools.py
+++ b/src/recipe_board/agents/graph_tools.py
@@ -1,0 +1,423 @@
+"""
+Tools for creating dependency graph visualizations from recipe data.
+"""
+
+import plotly.graph_objects as go
+import plotly.express as px
+from typing import Dict, List, Tuple, Any
+import math
+from ..core.state import RecipeSessionState
+from wasabi import msg
+
+
+def create_dependency_graph(state: RecipeSessionState) -> go.Figure:
+    """
+    Create a network dependency graph from recipe state.
+
+    Uses a tripartite graph structure:
+    - Ingredient nodes (green circles)
+    - Action nodes (blue diamonds)
+    - Equipment nodes (orange squares)
+    - Edges connect ingredients → actions and actions → equipment
+
+    Args:
+        state: RecipeSessionState with parsed ingredients, equipment, and actions
+
+    Returns:
+        Plotly Figure object with interactive network graph
+    """
+    if not state.actions:
+        # Return empty figure with message
+        fig = go.Figure()
+        fig.add_annotation(
+            text="No actions found. Parse recipe actions first to generate dependency graph.",
+            xref="paper",
+            yref="paper",
+            x=0.5,
+            y=0.5,
+            xanchor="center",
+            yanchor="middle",
+            showarrow=False,
+            font=dict(size=16, color="gray"),
+        )
+        fig.update_layout(
+            title="Recipe Dependency Graph",
+            showlegend=False,
+            xaxis={"visible": False},
+            yaxis={"visible": False},
+        )
+        return fig
+
+    # Build node and edge data
+    nodes, edges = _build_graph_data(state)
+
+    # Calculate node positions using force-directed layout
+    node_positions = _calculate_force_directed_positions(nodes, edges)
+
+    # Create edge traces
+    edge_traces = _create_edge_traces(edges, node_positions)
+
+    # Create node traces by type
+    node_traces = _create_node_traces(nodes, node_positions)
+
+    # Combine all traces
+    fig_data = edge_traces + node_traces
+
+    # Configure layout
+    fig = go.Figure(data=fig_data)
+    fig.update_layout(
+        title=dict(text="Recipe Dependency Graph", font=dict(size=16)),
+        showlegend=True,
+        hovermode="closest",
+        margin=dict(b=20, l=5, r=5, t=40),
+        annotations=[
+            dict(
+                text="Hover over nodes for details. Drag to explore the network.",
+                showarrow=False,
+                xref="paper",
+                yref="paper",
+                x=0.005,
+                y=-0.002,
+                xanchor="left",
+                yanchor="bottom",
+                font=dict(color="gray", size=12),
+            )
+        ],
+        xaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+        yaxis=dict(showgrid=False, zeroline=False, showticklabels=False),
+        plot_bgcolor="white",
+    )
+
+    return fig
+
+
+def _build_graph_data(state: RecipeSessionState) -> Tuple[List[Dict], List[Dict]]:
+    """Build nodes and edges data structures from recipe state."""
+    nodes = []
+    edges = []
+
+    # Create ingredient nodes
+    for ingredient in state.ingredients:
+        nodes.append(
+            {
+                "id": ingredient.id,
+                "name": ingredient.name,
+                "type": "ingredient",
+                "size": 20,
+                "color": "#2E8B57",  # Sea green
+                "symbol": "circle",
+                "hover_text": _format_ingredient_hover(ingredient),
+            }
+        )
+
+    # Create equipment nodes
+    for equipment in state.equipment:
+        nodes.append(
+            {
+                "id": equipment.id,
+                "name": equipment.name,
+                "type": "equipment",
+                "size": 25,
+                "color": "#FF8C00",  # Dark orange
+                "symbol": "square",
+                "hover_text": _format_equipment_hover(equipment),
+            }
+        )
+
+    # Create action nodes and edges
+    for action in state.actions:
+        action_node_id = f"action_{action.id}"
+        nodes.append(
+            {
+                "id": action_node_id,
+                "name": action.name,
+                "type": "action",
+                "size": 30,
+                "color": "#4169E1",  # Royal blue
+                "symbol": "diamond",
+                "hover_text": _format_action_hover(action, state),
+            }
+        )
+
+        # Create edges from ingredients to action
+        for ingredient_id in action.ingredient_ids:
+            edges.append(
+                {
+                    "source": ingredient_id,
+                    "target": action_node_id,
+                    "type": "ingredient_to_action",
+                }
+            )
+
+        # Create edge from action to equipment
+        if action.equipment_ids:
+            edges.append(
+                {
+                    "source": action_node_id,
+                    "target": action.equipment_ids,
+                    "type": "action_to_equipment",
+                }
+            )
+
+    return nodes, edges
+
+
+def _format_ingredient_hover(ingredient) -> str:
+    """Format hover text for ingredient nodes."""
+    parts = [f"<b>{ingredient.name}</b>"]
+    if ingredient.amount:
+        amount_text = f"{ingredient.amount}"
+        if ingredient.unit:
+            amount_text += f" {ingredient.unit}"
+        parts.append(f"Amount: {amount_text}")
+    if ingredient.modifiers:
+        parts.append(f"Modifiers: {', '.join(ingredient.modifiers)}")
+    return "<br>".join(parts)
+
+
+def _format_equipment_hover(equipment) -> str:
+    """Format hover text for equipment nodes."""
+    parts = [f"<b>{equipment.name}</b>"]
+    parts.append(f"Required: {'Yes' if equipment.required else 'No'}")
+    if equipment.modifiers:
+        parts.append(f"Modifiers: {equipment.modifiers}")
+    return "<br>".join(parts)
+
+
+def _format_action_hover(action, state: RecipeSessionState) -> str:
+    """Format hover text for action nodes."""
+    parts = [f"<b>Action: {action.name}</b>"]
+
+    # Find ingredient names
+    if action.ingredient_ids:
+        ingredient_names = [
+            ing.name for ing in state.ingredients if ing.id in action.ingredient_ids
+        ]
+        if ingredient_names:
+            parts.append(f"Ingredients: {', '.join(ingredient_names)}")
+
+    # Find equipment name
+    if action.equipment_ids:
+        equipment_name = next(
+            (eq.name for eq in state.equipment if eq.id == action.equipment_ids),
+            "Unknown",
+        )
+        parts.append(f"Equipment: {equipment_name}")
+
+    return "<br>".join(parts)
+
+
+def _calculate_force_directed_positions(
+    nodes: List[Dict], edges: List[Dict]
+) -> Dict[str, Tuple[float, float]]:
+    """Calculate node positions using simple force-directed algorithm."""
+    node_positions = {}
+    node_count = len(nodes)
+
+    if node_count == 0:
+        return node_positions
+
+    # Initialize positions in a circle
+    for i, node in enumerate(nodes):
+        angle = 2 * math.pi * i / node_count
+        radius = max(1.0, node_count / 6)  # Scale radius with node count
+        x = radius * math.cos(angle)
+        y = radius * math.sin(angle)
+        node_positions[node["id"]] = (x, y)
+
+    # Simple force-directed adjustment
+    for iteration in range(50):  # Limited iterations for performance
+        forces = {node_id: [0.0, 0.0] for node_id in node_positions}
+
+        # Repulsive forces between all nodes
+        for i, node1 in enumerate(nodes):
+            for j, node2 in enumerate(nodes):
+                if i >= j:
+                    continue
+
+                x1, y1 = node_positions[node1["id"]]
+                x2, y2 = node_positions[node2["id"]]
+
+                dx = x2 - x1
+                dy = y2 - y1
+                distance = max(0.1, math.sqrt(dx * dx + dy * dy))
+
+                # Repulsive force
+                force_magnitude = 0.1 / (distance * distance)
+                fx = force_magnitude * dx / distance
+                fy = force_magnitude * dy / distance
+
+                forces[node1["id"]][0] -= fx
+                forces[node1["id"]][1] -= fy
+                forces[node2["id"]][0] += fx
+                forces[node2["id"]][1] += fy
+
+        # Attractive forces for connected nodes
+        for edge in edges:
+            source_id = edge["source"]
+            target_id = edge["target"]
+
+            if source_id not in node_positions or target_id not in node_positions:
+                continue
+
+            x1, y1 = node_positions[source_id]
+            x2, y2 = node_positions[target_id]
+
+            dx = x2 - x1
+            dy = y2 - y1
+            distance = max(0.1, math.sqrt(dx * dx + dy * dy))
+
+            # Attractive force
+            force_magnitude = 0.02 * distance
+            fx = force_magnitude * dx / distance
+            fy = force_magnitude * dy / distance
+
+            forces[source_id][0] += fx
+            forces[source_id][1] += fy
+            forces[target_id][0] -= fx
+            forces[target_id][1] -= fy
+
+        # Apply forces
+        for node_id in node_positions:
+            x, y = node_positions[node_id]
+            fx, fy = forces[node_id]
+
+            # Damping factor
+            damping = 0.1
+            x += fx * damping
+            y += fy * damping
+
+            node_positions[node_id] = (x, y)
+
+    return node_positions
+
+
+def _create_edge_traces(
+    edges: List[Dict], node_positions: Dict[str, Tuple[float, float]]
+) -> List[go.Scatter]:
+    """Create edge traces for the graph."""
+    edge_x = []
+    edge_y = []
+
+    for edge in edges:
+        source_id = edge["source"]
+        target_id = edge["target"]
+
+        if source_id in node_positions and target_id in node_positions:
+            x0, y0 = node_positions[source_id]
+            x1, y1 = node_positions[target_id]
+
+            edge_x.extend([x0, x1, None])
+            edge_y.extend([y0, y1, None])
+
+    edge_trace = go.Scatter(
+        x=edge_x,
+        y=edge_y,
+        line=dict(width=2, color="#888"),
+        hoverinfo="none",
+        mode="lines",
+        showlegend=False,
+    )
+
+    return [edge_trace]
+
+
+def _create_node_traces(
+    nodes: List[Dict], node_positions: Dict[str, Tuple[float, float]]
+) -> List[go.Scatter]:
+    """Create node traces grouped by type."""
+    traces = []
+
+    # Group nodes by type
+    node_types = {"ingredient": [], "action": [], "equipment": []}
+    for node in nodes:
+        node_type = node["type"]
+        if node_type in node_types:
+            node_types[node_type].append(node)
+
+    # Create trace for each node type
+    type_configs = {
+        "ingredient": {"name": "Ingredients", "symbol": "circle"},
+        "action": {"name": "Actions", "symbol": "diamond"},
+        "equipment": {"name": "Equipment", "symbol": "square"},
+    }
+
+    for node_type, type_nodes in node_types.items():
+        if not type_nodes:
+            continue
+
+        config = type_configs[node_type]
+
+        # Extract data for this node type
+        x_vals = []
+        y_vals = []
+        texts = []
+        hovers = []
+        colors = []
+        sizes = []
+
+        for node in type_nodes:
+            if node["id"] in node_positions:
+                x, y = node_positions[node["id"]]
+                x_vals.append(x)
+                y_vals.append(y)
+                texts.append(node["name"])
+                hovers.append(node["hover_text"])
+                colors.append(node["color"])
+                sizes.append(node["size"])
+
+        if x_vals:  # Only create trace if we have data
+            trace = go.Scatter(
+                x=x_vals,
+                y=y_vals,
+                mode="markers+text",
+                name=config["name"],
+                text=texts,
+                textposition="middle center",
+                textfont=dict(size=10, color="white"),
+                hoverinfo="text",
+                hovertext=hovers,
+                marker=dict(
+                    symbol=config["symbol"],
+                    size=sizes,
+                    color=(
+                        colors[0] if colors else "#888"
+                    ),  # Use consistent color per type
+                    line=dict(width=2, color="white"),
+                ),
+            )
+            traces.append(trace)
+
+    return traces
+
+
+def generate_graph_download_data(fig: go.Figure) -> Dict[str, Any]:
+    """
+    Generate data for downloading the graph in various formats.
+
+    Args:
+        fig: Plotly figure object
+
+    Returns:
+        Dictionary with download options and data
+    """
+    try:
+        # Generate different format options
+        download_data = {
+            "html": fig.to_html(include_plotlyjs=True),
+            "json": fig.to_json(),
+            "png_available": True,  # Plotly supports PNG export
+            "svg_available": True,  # Plotly supports SVG export
+        }
+
+        msg.info("Graph download data generated successfully")
+        return download_data
+
+    except Exception as e:
+        msg.warn(f"Error generating download data: {e}")
+        return {
+            "html": None,
+            "json": None,
+            "png_available": False,
+            "svg_available": False,
+        }

--- a/src/recipe_board/core/recipe.py
+++ b/src/recipe_board/core/recipe.py
@@ -31,6 +31,7 @@ class Equipment(BaseModel):
 
 
 class Action(BaseModel):
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str
     ingredient_ids: list[str]
     equipment_ids: str

--- a/src/recipe_board/core/state.py
+++ b/src/recipe_board/core/state.py
@@ -92,10 +92,11 @@ class RecipeSessionState:
                 ]
                 parts.append(f"Ingredients: {', '.join(ing_names)}")
             if action.equipment_ids:
-                eq_names = [
-                    eq.name for eq in self.equipment if eq.id == action.equipment_ids
-                ]
-                parts.append(f"Equipment: {', '.join(eq_names)}")
+                eq_name = next(
+                    (eq.name for eq in self.equipment if eq.id == action.equipment_ids),
+                    "Unknown",
+                )
+                parts.append(f"Equipment: {eq_name}")
             formatted.append(" | ".join(parts))
 
         return "\n".join(f"- {item}" for item in formatted)

--- a/test/test_graph_integration.py
+++ b/test/test_graph_integration.py
@@ -1,0 +1,162 @@
+"""
+Integration test for end-to-end graph visualization workflow.
+"""
+
+import pytest
+from recipe_board.core.state import RecipeSessionState
+from recipe_board.core.recipe import Ingredient, Equipment, Action
+from recipe_board.agents.graph_tools import create_dependency_graph
+import plotly.graph_objects as go
+
+
+class TestGraphIntegration:
+    """Integration tests for graph visualization workflow."""
+
+    def test_complete_recipe_to_graph_workflow(self):
+        """Test complete workflow from recipe state to dependency graph."""
+        # Create a realistic recipe state
+        state = RecipeSessionState()
+        state.raw_text = "Mix flour and salt in a large bowl using a whisk. Bake in preheated oven."
+        state.workflow_step = "actions_parsed"
+
+        # Add ingredients
+        flour = Ingredient(
+            name="flour",
+            amount=2.0,
+            unit="cups",
+            modifiers=["all-purpose"],
+            raw_text="2 cups all-purpose flour"
+        )
+        salt = Ingredient(
+            name="salt",
+            amount=1.0,
+            unit="tsp",
+            modifiers=[],
+            raw_text="1 tsp salt"
+        )
+        state.ingredients = [flour, salt]
+
+        # Add equipment
+        bowl = Equipment(name="mixing bowl", required=True, modifiers="large")
+        whisk = Equipment(name="whisk", required=True, modifiers=None)
+        oven = Equipment(name="oven", required=True, modifiers="preheated")
+        state.equipment = [bowl, whisk, oven]
+
+        # Add actions linking everything together
+        mix_action = Action(
+            name="mix",
+            ingredient_ids=[flour.id, salt.id],
+            equipment_ids=bowl.id
+        )
+        whisk_action = Action(
+            name="whisk",
+            ingredient_ids=[flour.id, salt.id],
+            equipment_ids=whisk.id
+        )
+        bake_action = Action(
+            name="bake",
+            ingredient_ids=[flour.id],  # Assuming mixed flour goes to baking
+            equipment_ids=oven.id
+        )
+        state.actions = [mix_action, whisk_action, bake_action]
+
+        # Generate graph
+        fig = create_dependency_graph(state)
+
+        # Verify graph structure
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) > 0  # Should have traces
+
+        # Verify we have different node types
+        node_traces = [trace for trace in fig.data if hasattr(trace, 'name') and trace.name]
+        trace_names = [trace.name for trace in node_traces]
+
+        # Should have ingredients, actions, and equipment traces
+        expected_types = ['Ingredients', 'Actions', 'Equipment']
+        found_types = [name for name in expected_types if name in trace_names]
+        assert len(found_types) >= 2  # At least 2 of the 3 types should be present
+
+        # Verify title
+        assert "Recipe Dependency Graph" in fig.layout.title.text
+
+    def test_minimal_recipe_graph(self):
+        """Test graph creation with minimal recipe data."""
+        state = RecipeSessionState()
+
+        # Single ingredient, equipment, action
+        ingredient = Ingredient(name="egg", amount=1, unit="piece", modifiers=[], raw_text="1 egg")
+        equipment = Equipment(name="pan", required=True, modifiers=None)
+        action = Action(name="crack", ingredient_ids=[ingredient.id], equipment_ids=equipment.id)
+
+        state.ingredients = [ingredient]
+        state.equipment = [equipment]
+        state.actions = [action]
+
+        fig = create_dependency_graph(state)
+
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) > 0
+
+        # Should have at least one edge connecting nodes
+        edge_traces = [trace for trace in fig.data if trace.mode == 'lines']
+        assert len(edge_traces) >= 1
+
+    def test_complex_recipe_graph(self):
+        """Test graph creation with complex recipe having multiple connections."""
+        state = RecipeSessionState()
+
+        # Multiple ingredients
+        ingredients = [
+            Ingredient(name="flour", amount=2, unit="cups", modifiers=[], raw_text="2 cups flour"),
+            Ingredient(name="sugar", amount=1, unit="cup", modifiers=[], raw_text="1 cup sugar"),
+            Ingredient(name="eggs", amount=3, unit="pieces", modifiers=[], raw_text="3 eggs"),
+            Ingredient(name="butter", amount=0.5, unit="cup", modifiers=["melted"], raw_text="1/2 cup melted butter")
+        ]
+
+        # Multiple equipment pieces
+        equipment = [
+            Equipment(name="mixing bowl", required=True, modifiers="large"),
+            Equipment(name="whisk", required=True, modifiers=None),
+            Equipment(name="baking pan", required=True, modifiers="9x13 inch"),
+            Equipment(name="oven", required=True, modifiers="preheated to 350°F")
+        ]
+
+        # Multiple actions with various connections
+        actions = [
+            Action(name="mix", ingredient_ids=[ingredients[0].id, ingredients[1].id], equipment_ids=equipment[0].id),
+            Action(name="whisk", ingredient_ids=[ingredients[2].id], equipment_ids=equipment[1].id),
+            Action(name="combine", ingredient_ids=[ingredients[0].id, ingredients[2].id, ingredients[3].id], equipment_ids=equipment[0].id),
+            Action(name="bake", ingredient_ids=[ingredients[0].id], equipment_ids=equipment[3].id)
+        ]
+
+        state.ingredients = ingredients
+        state.equipment = equipment
+        state.actions = actions
+
+        fig = create_dependency_graph(state)
+
+        assert isinstance(fig, go.Figure)
+
+        # Should have multiple traces for different node types
+        traces_with_names = [trace for trace in fig.data if hasattr(trace, 'name') and trace.name]
+        assert len(traces_with_names) >= 3  # Should have ingredients, actions, equipment
+
+        # Verify we have edge connections
+        edge_traces = [trace for trace in fig.data if hasattr(trace, 'mode') and trace.mode == 'lines']
+        assert len(edge_traces) >= 1
+
+        # Complex recipe should have many data points
+        total_data_points = sum(len(trace.x) if hasattr(trace, 'x') and trace.x else 0 for trace in fig.data)
+        assert total_data_points > 10  # Should have many nodes and edges
+
+    def test_empty_state_graceful_handling(self):
+        """Test that empty state is handled gracefully."""
+        state = RecipeSessionState()
+        # No ingredients, equipment, or actions
+
+        fig = create_dependency_graph(state)
+
+        assert isinstance(fig, go.Figure)
+        # Should have annotation explaining no actions found
+        assert len(fig.layout.annotations) > 0
+        assert "No actions found" in fig.layout.annotations[0].text

--- a/test/test_graph_tools.py
+++ b/test/test_graph_tools.py
@@ -1,0 +1,354 @@
+"""
+Unit tests for graph visualization tools.
+"""
+
+import pytest
+import plotly.graph_objects as go
+from recipe_board.agents.graph_tools import (
+    create_dependency_graph,
+    generate_graph_download_data,
+    _build_graph_data,
+    _calculate_force_directed_positions,
+    _format_ingredient_hover,
+    _format_equipment_hover,
+    _format_action_hover,
+)
+from recipe_board.core.state import RecipeSessionState
+from recipe_board.core.recipe import Ingredient, Equipment, Action
+
+
+class TestCreateDependencyGraph:
+    """Test suite for create_dependency_graph function."""
+
+    def test_empty_actions_returns_message_figure(self):
+        """Test that empty actions returns a figure with informational message."""
+        state = RecipeSessionState()
+        state.ingredients = [
+            Ingredient(name="flour", amount=2.0, unit="cups", modifiers=[], raw_text="2 cups flour")
+        ]
+        state.equipment = [
+            Equipment(name="bowl", required=True, modifiers=None)
+        ]
+        # No actions
+
+        fig = create_dependency_graph(state)
+
+        assert isinstance(fig, go.Figure)
+        # Should have annotation with message about no actions
+        assert len(fig.layout.annotations) > 0
+        assert "No actions found" in fig.layout.annotations[0].text
+
+    def test_with_actions_creates_network_graph(self):
+        """Test that valid state with actions creates proper network graph."""
+        state = RecipeSessionState()
+
+        # Create ingredients with specific IDs for testing
+        ingredient1 = Ingredient(name="flour", amount=2.0, unit="cups", modifiers=[], raw_text="2 cups flour")
+        ingredient2 = Ingredient(name="salt", amount=1.0, unit="tsp", modifiers=[], raw_text="1 tsp salt")
+        state.ingredients = [ingredient1, ingredient2]
+
+        # Create equipment with specific ID
+        equipment1 = Equipment(name="mixing bowl", required=True, modifiers="large")
+        state.equipment = [equipment1]
+
+        # Create action linking ingredients to equipment
+        action1 = Action(
+            name="mix",
+            ingredient_ids=[ingredient1.id, ingredient2.id],
+            equipment_ids=equipment1.id
+        )
+        state.actions = [action1]
+
+        fig = create_dependency_graph(state)
+
+        assert isinstance(fig, go.Figure)
+        assert len(fig.data) > 0  # Should have traces for nodes and edges
+        assert fig.layout.title.text == "Recipe Dependency Graph"
+
+    def test_graph_has_proper_traces(self):
+        """Test that graph contains expected node and edge traces."""
+        state = RecipeSessionState()
+
+        ingredient1 = Ingredient(name="flour", amount=2.0, unit="cups", modifiers=[], raw_text="2 cups flour")
+        state.ingredients = [ingredient1]
+
+        equipment1 = Equipment(name="bowl", required=True, modifiers=None)
+        state.equipment = [equipment1]
+
+        action1 = Action(name="mix", ingredient_ids=[ingredient1.id], equipment_ids=equipment1.id)
+        state.actions = [action1]
+
+        fig = create_dependency_graph(state)
+
+        # Should have edge trace plus node traces (ingredients, actions, equipment)
+        assert len(fig.data) >= 2  # At least edges + some node traces
+
+        # Check for different trace types
+        trace_names = [trace.name for trace in fig.data if hasattr(trace, 'name') and trace.name]
+        expected_traces = ['Ingredients', 'Actions', 'Equipment']
+
+        # At least some of these should be present
+        found_traces = [name for name in expected_traces if name in trace_names]
+        assert len(found_traces) > 0
+
+
+class TestBuildGraphData:
+    """Test suite for _build_graph_data function."""
+
+    def test_empty_state_returns_empty_data(self):
+        """Test that empty state returns empty nodes and edges."""
+        state = RecipeSessionState()
+
+        nodes, edges = _build_graph_data(state)
+
+        assert nodes == []
+        assert edges == []
+
+    def test_ingredients_become_nodes(self):
+        """Test that ingredients are converted to nodes properly."""
+        state = RecipeSessionState()
+        ingredient = Ingredient(name="flour", amount=2.0, unit="cups", modifiers=["all-purpose"], raw_text="2 cups flour")
+        state.ingredients = [ingredient]
+
+        nodes, edges = _build_graph_data(state)
+
+        assert len(nodes) == 1
+        node = nodes[0]
+        assert node['id'] == ingredient.id
+        assert node['name'] == "flour"
+        assert node['type'] == 'ingredient'
+        assert node['color'] == '#2E8B57'  # Sea green
+        assert "flour" in node['hover_text']
+
+    def test_equipment_becomes_nodes(self):
+        """Test that equipment is converted to nodes properly."""
+        state = RecipeSessionState()
+        equipment = Equipment(name="bowl", required=True, modifiers="large")
+        state.equipment = [equipment]
+
+        nodes, edges = _build_graph_data(state)
+
+        assert len(nodes) == 1
+        node = nodes[0]
+        assert node['id'] == equipment.id
+        assert node['name'] == "bowl"
+        assert node['type'] == 'equipment'
+        assert node['color'] == '#FF8C00'  # Dark orange
+
+    def test_actions_create_nodes_and_edges(self):
+        """Test that actions create action nodes and connecting edges."""
+        state = RecipeSessionState()
+
+        ingredient = Ingredient(name="flour", amount=2.0, unit="cups", modifiers=[], raw_text="2 cups flour")
+        equipment = Equipment(name="bowl", required=True, modifiers=None)
+        action = Action(name="mix", ingredient_ids=[ingredient.id], equipment_ids=equipment.id)
+
+        state.ingredients = [ingredient]
+        state.equipment = [equipment]
+        state.actions = [action]
+
+        nodes, edges = _build_graph_data(state)
+
+        # Should have 3 nodes: ingredient, equipment, action
+        assert len(nodes) == 3
+
+        # Find action node
+        action_nodes = [n for n in nodes if n['type'] == 'action']
+        assert len(action_nodes) == 1
+        action_node = action_nodes[0]
+        assert action_node['name'] == "mix"
+        assert action_node['color'] == '#4169E1'  # Royal blue
+
+        # Should have 2 edges: ingredient->action, action->equipment
+        assert len(edges) == 2
+
+        # Check edge connections
+        ingredient_to_action = next((e for e in edges if e['source'] == ingredient.id), None)
+        assert ingredient_to_action is not None
+        assert ingredient_to_action['target'] == action_node['id']
+        assert ingredient_to_action['type'] == 'ingredient_to_action'
+
+        action_to_equipment = next((e for e in edges if e['source'] == action_node['id']), None)
+        assert action_to_equipment is not None
+        assert action_to_equipment['target'] == equipment.id
+        assert action_to_equipment['type'] == 'action_to_equipment'
+
+
+class TestHoverTextFormatting:
+    """Test suite for hover text formatting functions."""
+
+    def test_format_ingredient_hover_complete(self):
+        """Test ingredient hover formatting with all fields."""
+        ingredient = Ingredient(
+            name="flour",
+            amount=2.5,
+            unit="cups",
+            modifiers=["all-purpose", "sifted"],
+            raw_text="2.5 cups flour"
+        )
+
+        hover_text = _format_ingredient_hover(ingredient)
+
+        assert "<b>flour</b>" in hover_text
+        assert "Amount: 2.5 cups" in hover_text
+        assert "Modifiers: all-purpose, sifted" in hover_text
+
+    def test_format_ingredient_hover_minimal(self):
+        """Test ingredient hover formatting with minimal fields."""
+        ingredient = Ingredient(name="salt", amount=None, unit=None, modifiers=[], raw_text="salt")
+
+        hover_text = _format_ingredient_hover(ingredient)
+
+        assert "<b>salt</b>" in hover_text
+        assert "Amount:" not in hover_text
+        assert "Modifiers:" not in hover_text
+
+    def test_format_equipment_hover(self):
+        """Test equipment hover formatting."""
+        equipment = Equipment(name="mixing bowl", required=True, modifiers="large")
+
+        hover_text = _format_equipment_hover(equipment)
+
+        assert "<b>mixing bowl</b>" in hover_text
+        assert "Required: Yes" in hover_text
+        assert "Modifiers: large" in hover_text
+
+    def test_format_equipment_hover_not_required(self):
+        """Test equipment hover formatting when not required."""
+        equipment = Equipment(name="whisk", required=False, modifiers=None)
+
+        hover_text = _format_equipment_hover(equipment)
+
+        assert "<b>whisk</b>" in hover_text
+        assert "Required: No" in hover_text
+        assert "Modifiers:" not in hover_text
+
+    def test_format_action_hover(self):
+        """Test action hover formatting."""
+        state = RecipeSessionState()
+
+        ingredient1 = Ingredient(name="flour", amount=2.0, unit="cups", modifiers=[], raw_text="2 cups flour")
+        ingredient2 = Ingredient(name="salt", amount=1.0, unit="tsp", modifiers=[], raw_text="1 tsp salt")
+        equipment = Equipment(name="bowl", required=True, modifiers=None)
+
+        state.ingredients = [ingredient1, ingredient2]
+        state.equipment = [equipment]
+
+        action = Action(
+            name="mix",
+            ingredient_ids=[ingredient1.id, ingredient2.id],
+            equipment_ids=equipment.id
+        )
+
+        hover_text = _format_action_hover(action, state)
+
+        assert "<b>Action: mix</b>" in hover_text
+        assert "Ingredients: flour, salt" in hover_text
+        assert "Equipment: bowl" in hover_text
+
+
+class TestForceDirectedPositions:
+    """Test suite for _calculate_force_directed_positions function."""
+
+    def test_empty_nodes_returns_empty_positions(self):
+        """Test that empty nodes list returns empty positions."""
+        positions = _calculate_force_directed_positions([], [])
+        assert positions == {}
+
+    def test_single_node_has_position(self):
+        """Test that single node gets a position."""
+        nodes = [{'id': 'node1', 'name': 'test'}]
+        edges = []
+
+        positions = _calculate_force_directed_positions(nodes, edges)
+
+        assert 'node1' in positions
+        x, y = positions['node1']
+        assert isinstance(x, (int, float))
+        assert isinstance(y, (int, float))
+
+    def test_multiple_nodes_have_different_positions(self):
+        """Test that multiple nodes get different positions."""
+        nodes = [
+            {'id': 'node1', 'name': 'test1'},
+            {'id': 'node2', 'name': 'test2'},
+            {'id': 'node3', 'name': 'test3'}
+        ]
+        edges = []
+
+        positions = _calculate_force_directed_positions(nodes, edges)
+
+        assert len(positions) == 3
+        position_values = list(positions.values())
+
+        # All positions should be different
+        assert len(set(position_values)) == 3
+
+    def test_connected_nodes_influence_positions(self):
+        """Test that edges influence node positions."""
+        nodes = [
+            {'id': 'node1', 'name': 'test1'},
+            {'id': 'node2', 'name': 'test2'}
+        ]
+        edges = [{'source': 'node1', 'target': 'node2', 'type': 'test'}]
+
+        positions = _calculate_force_directed_positions(nodes, edges)
+
+        assert len(positions) == 2
+        assert 'node1' in positions
+        assert 'node2' in positions
+
+
+class TestGenerateGraphDownloadData:
+    """Test suite for generate_graph_download_data function."""
+
+    def test_generates_download_data(self):
+        """Test that download data is generated properly."""
+        # Create a simple figure
+        fig = go.Figure(data=go.Scatter(x=[1, 2, 3], y=[4, 5, 6]))
+        fig.update_layout(title="Test Graph")
+
+        download_data = generate_graph_download_data(fig)
+
+        assert isinstance(download_data, dict)
+        assert 'html' in download_data
+        assert 'json' in download_data
+        assert 'png_available' in download_data
+        assert 'svg_available' in download_data
+
+        # HTML and JSON should be strings
+        assert isinstance(download_data['html'], str)
+        assert isinstance(download_data['json'], str)
+
+        # Availability flags should be boolean
+        assert isinstance(download_data['png_available'], bool)
+        assert isinstance(download_data['svg_available'], bool)
+
+    def test_html_contains_plotly_content(self):
+        """Test that HTML download contains Plotly content."""
+        fig = go.Figure(data=go.Scatter(x=[1, 2], y=[3, 4]))
+        fig.update_layout(title="Test Graph")
+
+        download_data = generate_graph_download_data(fig)
+        html_content = download_data['html']
+
+        assert "Test Graph" in html_content
+        assert "plotly" in html_content.lower()
+
+    def test_json_is_valid_plotly_json(self):
+        """Test that JSON download is valid Plotly JSON."""
+        import json
+
+        fig = go.Figure(data=go.Scatter(x=[1, 2], y=[3, 4]))
+        fig.update_layout(title="Test Graph")
+
+        download_data = generate_graph_download_data(fig)
+        json_content = download_data['json']
+
+        # Should be valid JSON
+        parsed_json = json.loads(json_content)
+        assert isinstance(parsed_json, dict)
+
+        # Should have Plotly structure
+        assert 'data' in parsed_json
+        assert 'layout' in parsed_json

--- a/uv.lock
+++ b/uv.lock
@@ -605,6 +605,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "1.42.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/7e/9484c2427453bd0024fd36cf7923de4367d749f0b216b9ca56b9dfc3c516/narwhals-1.42.0.tar.gz", hash = "sha256:a5e554782446d1197593312651352cd39b2025e995053d8e6bdfaa01a70a91d3", size = 490671, upload-time = "2025-06-09T09:20:27.794Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/0f/f9ae7c8c55f9078c852b13ea4a6e92e5f4d6d4c8fc0781ec2882957006bb/narwhals-1.42.0-py3-none-any.whl", hash = "sha256:ef6cedf7700dc22c09d17973b9ede11b53e25331e238b24ac73884a8c5e27c19", size = 359033, upload-time = "2025-06-09T09:20:25.668Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.9.1"
 source = { registry = "https://pypi.org/simple" }
@@ -746,6 +755,19 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/fe/8b/3c73abc9c759ecd3f1f7ceff6685840859e8070c4d947c93fae71f6a0bf2/platformdirs-4.3.8.tar.gz", hash = "sha256:3d512d96e16bcb959a814c9f348431070822a6496326a4be0911c40b5a74c2bc", size = 21362, upload-time = "2025-05-07T22:47:42.121Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/39/979e8e21520d4e47a0bbe349e2713c0aac6f3d853d0e5b34d76206c439aa/platformdirs-4.3.8-py3-none-any.whl", hash = "sha256:ff7059bb7eb1179e2685604f4aaf157cfd9535242bd23742eadc3c13542139b4", size = 18567, upload-time = "2025-05-07T22:47:40.376Z" },
+]
+
+[[package]]
+name = "plotly"
+version = "6.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "narwhals" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/77/431447616eda6a432dc3ce541b3f808ecb8803ea3d4ab2573b67f8eb4208/plotly-6.1.2.tar.gz", hash = "sha256:4fdaa228926ba3e3a213f4d1713287e69dcad1a7e66cf2025bd7d7026d5014b4", size = 7662971, upload-time = "2025-05-27T20:21:52.56Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bf/6f/759d5da0517547a5d38aabf05d04d9f8adf83391d2c7fc33f904417d3ba2/plotly-6.1.2-py3-none-any.whl", hash = "sha256:f1548a8ed9158d59e03d7fed548c7db5549f3130d9ae19293c8638c202648f6d", size = 16265530, upload-time = "2025-05-27T20:21:46.6Z" },
 ]
 
 [[package]]
@@ -954,12 +976,13 @@ wheels = [
 [[package]]
 name = "recipe-board"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "en-core-web-lg" },
     { name = "gradio" },
     { name = "huggingface-hub" },
     { name = "pandas" },
+    { name = "plotly" },
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "smolagents" },
@@ -982,6 +1005,7 @@ requires-dist = [
     { name = "gradio", specifier = ">=5.0.0" },
     { name = "huggingface-hub", specifier = ">=0.32.4" },
     { name = "pandas", specifier = ">=2.0.0" },
+    { name = "plotly", specifier = ">=5.0.0" },
     { name = "pydantic", specifier = ">=2.11.5" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "smolagents", specifier = ">=1.17.0" },


### PR DESCRIPTION
Add visualization of the dependencies between ingredients, equipment, and actions.

This includes the key functionality of the visualization, as it seems that we started skipping a number of dependencies somewhere along the way (the Actions show quite a bit of duplication, when examined more closely).

The visualization should be useful from development/debugging perspective, and the skipped dependencies are pre-existing, so we will proceed with merging this.

![image](https://github.com/user-attachments/assets/ea22ae15-b836-4fb0-b9b3-16f0d8534f12)

