### PR TITLE
refactor: identify Actions earlier

### DIFF
--- a/src/recipe_board/agents/models.py
+++ b/src/recipe_board/agents/models.py
@@ -10,7 +10,7 @@ from .tools import (
     validate_action_structure,
 )
 from wasabi import msg
-from ..core.recipe import Ingredient, Equipment, Action
+from ..core.recipe import Ingredient, Equipment, Action, BasicAction
 from ..core.state import RecipeSessionState
 
 model = os.environ["HF_MODEL"]
@@ -43,45 +43,129 @@ def parse_recipe(recipe: str) -> RecipeSessionState:
     result = hf_client.text_generation(parse_equipment_prompt + recipe, model=model)
 
     if result is None or result == "":
-        msg.warn("No result returned!")
+        msg.warn("No result returned from LLM!")
         return state
+
+    # Log the raw response for debugging (truncated if very long)
+    result_preview = result[:500] + "..." if len(result) > 500 else result
+    msg.info(f"LLM raw response: {result_preview}")
 
     # Try to parse as JSON and convert to Pydantic objects
     try:
         import json
-        import re
 
-        # Strip markdown code blocks if present
-        clean_result = result.strip()
-        if clean_result.startswith("```json"):
-            clean_result = re.sub(r"```json\s*", "", clean_result)
-        if clean_result.startswith("```"):
-            clean_result = re.sub(r"```\s*", "", clean_result)
-        if clean_result.endswith("```"):
-            clean_result = re.sub(r"\s*```$", "", clean_result)
+        # Extract JSON from response using improved logic
+        clean_result = _extract_json_from_response(result)
+
+        # Log the cleaned response for debugging
+        clean_preview = (
+            clean_result[:300] + "..." if len(clean_result) > 300 else clean_result
+        )
+        msg.info(f"Cleaned response for JSON parsing: {clean_preview}")
 
         parsed = json.loads(clean_result)
 
         # Convert to structured state
-        ingredients, equipment = _convert_json_to_objects(parsed)
+        ingredients, equipment, basic_actions = _convert_json_to_objects(parsed)
         state.ingredients = ingredients
         state.equipment = equipment
+        state.basic_actions = basic_actions
         state.workflow_step = "parsed"
 
+        # Log successful parsing results
+        msg.good(
+            f"Successfully parsed recipe: {len(ingredients)} ingredients, {len(equipment)} equipment, {len(basic_actions)} basic actions"
+        )
+
         return state
 
-    except json.JSONDecodeError:
+    except json.JSONDecodeError as e:
+        # Provide detailed debugging information for JSON parsing failures
+        msg.fail(f"JSON parsing failed: {str(e)}")
+        msg.fail(f"JSON error at line {e.lineno}, column {e.colno}: {e.msg}")
+
+        # Show the problematic part of the response around the error
+        if hasattr(e, "pos") and e.pos < len(clean_result):
+            start = max(0, e.pos - 50)
+            end = min(len(clean_result), e.pos + 50)
+            context = clean_result[start:end]
+            error_marker = " " * (e.pos - start) + "^"
+            msg.fail(f"Error context: ...{context}...")
+            msg.fail(f"Error position: ...{error_marker}")
+
+        # Also log the full cleaned response for manual inspection
+        msg.fail(f"Full cleaned response that failed to parse: {clean_result}")
+
         # Fallback - return state with empty data but preserve raw text
-        msg.warn("Response is not valid JSON, returning empty state")
+        msg.warn("Returning empty state due to JSON parsing failure")
         return state
+
+    except Exception as e:
+        # Catch any other unexpected errors during parsing
+        msg.fail(f"Unexpected error during recipe parsing: {str(e)}")
+        msg.fail(f"Error type: {type(e).__name__}")
+
+        # Log the response that caused the issue
+        result_preview = result[:300] + "..." if len(result) > 300 else result
+        msg.fail(f"Response that caused error: {result_preview}")
+
+        # Return empty state but preserve raw text
+        msg.warn("Returning empty state due to unexpected parsing error")
+        return state
+
+
+def _extract_json_from_response(response: str) -> str:
+    """Extract JSON content from LLM response, handling various formats."""
+    import re
+
+    if not response or not response.strip():
+        return response.strip()
+
+    clean_result = response.strip()
+
+    # Look for JSON code blocks anywhere in the response (not just at the start)
+    json_match = re.search(r"```json\s*(.*?)\s*```", clean_result, re.DOTALL)
+    if json_match:
+        # Extract just the JSON content from the code block
+        extracted = json_match.group(1).strip()
+        msg.info("Extracted JSON from ```json code block")
+        return extracted
+
+    # Fallback: try to find any code block
+    code_match = re.search(r"```\s*(.*?)\s*```", clean_result, re.DOTALL)
+    if code_match:
+        extracted = code_match.group(1).strip()
+        msg.info("Extracted content from generic ``` code block")
+        return extracted
+
+    # No code blocks found, but there might be text before/after JSON
+    # Try to extract JSON object from the response
+    json_obj_match = re.search(r"\{.*\}", clean_result, re.DOTALL)
+    if json_obj_match:
+        extracted = json_obj_match.group(0).strip()
+        msg.info("Extracted JSON object from response text")
+        return extracted
+
+    # No JSON structure found, return original
+    msg.warn("No JSON structure found in response")
+    return clean_result
 
 
 def _convert_json_to_objects(
     parsed_json: dict,
-) -> tuple[list[Ingredient], list[Equipment]]:
-    """Convert parsed JSON to Ingredient and Equipment objects."""
+) -> tuple[list[Ingredient], list[Equipment], list[BasicAction]]:
+    """Convert parsed JSON to Ingredient, Equipment, and BasicAction objects."""
+
+    # Log the structure of the parsed JSON for debugging
+    if isinstance(parsed_json, dict):
+        available_keys = list(parsed_json.keys())
+        msg.info(f"Parsed JSON contains keys: {available_keys}")
+    else:
+        msg.warn(f"Expected dict but got {type(parsed_json)}: {parsed_json}")
+
     ingredients_data = parsed_json.get("ingredients", [])
     equipment_data = parsed_json.get("equipment", [])
+    basic_actions_data = parsed_json.get("basic_actions", [])
 
     if not isinstance(ingredients_data, list):
         msg.warn("'ingredients' must be an array")
@@ -89,6 +173,14 @@ def _convert_json_to_objects(
     if not isinstance(equipment_data, list):
         msg.warn("'equipment' must be an array")
         equipment_data = []
+    if not isinstance(basic_actions_data, list):
+        msg.warn("'basic_actions' must be an array")
+        basic_actions_data = []
+
+    # Log what we're attempting to convert
+    msg.info(
+        f"Converting: {len(ingredients_data)} ingredients, {len(equipment_data)} equipment, {len(basic_actions_data)} basic actions"
+    )
 
     # Convert ingredients
     ingredients = []
@@ -151,7 +243,25 @@ def _convert_json_to_objects(
             msg.warn(f"Failed to create equipment from {item}: {e}")
             continue
 
-    return ingredients, equipment_list
+    # Convert basic actions
+    basic_actions_list = []
+    for item in basic_actions_data:
+        if not isinstance(item, dict):
+            msg.warn(f"Skipping invalid basic action item: {item}")
+            continue
+
+        try:
+            basic_action = BasicAction(
+                verb=item.get("verb", ""),
+                sentence=item.get("sentence", ""),
+                sentence_index=item.get("sentence_index", 0),
+            )
+            basic_actions_list.append(basic_action)
+        except Exception as e:
+            msg.warn(f"Failed to create basic action from {item}: {e}")
+            continue
+
+    return ingredients, equipment_list, basic_actions_list
 
 
 def ingredients_and_equipment_from_parsed_recipe(
@@ -257,14 +367,17 @@ def ingredients_and_equipment_from_parsed_recipe(
         raise
 
 
-def parse_actions(state: RecipeSessionState) -> RecipeSessionState:
-    """Parse actions from recipe state using agent with spaCy tools.
+def parse_dependencies(state: RecipeSessionState) -> RecipeSessionState:
+    """Parse action dependencies from recipe state with pre-identified basic actions.
+
+    This function takes basic actions identified in the first pass and links them
+    to specific ingredient and equipment IDs using smolagents with spaCy tools.
 
     Args:
-        state: RecipeSessionState with parsed ingredients and equipment
+        state: RecipeSessionState with parsed ingredients, equipment, and basic_actions
 
     Returns:
-        Updated RecipeSessionState with parsed actions
+        Updated RecipeSessionState with parsed actions (linked dependencies)
 
     Raises:
         ValueError: If state is invalid or agent request fails
@@ -272,7 +385,11 @@ def parse_actions(state: RecipeSessionState) -> RecipeSessionState:
     import json
 
     if not state.ingredients and not state.equipment:
-        msg.warn("No ingredients or equipment found, cannot parse actions")
+        msg.warn("No ingredients or equipment found, cannot parse dependencies")
+        return state
+
+    if not state.basic_actions:
+        msg.warn("No basic actions found, cannot parse dependencies")
         return state
 
     # Set up the agent with tools
@@ -281,14 +398,13 @@ def parse_actions(state: RecipeSessionState) -> RecipeSessionState:
 
         agent = CodeAgent(
             tools=[
-                extract_verbs,
                 find_ingredients_in_sentence,
                 find_equipment_in_sentence,
                 filter_valid_actions,
                 validate_action_structure,
             ],
             model=hf_model,
-            max_steps=10,
+            max_steps=8,  # Reduced since we don't need extract_verbs
         )
     except Exception as e:
         msg.fail(f"Error creating agent: {e}")
@@ -298,14 +414,16 @@ def parse_actions(state: RecipeSessionState) -> RecipeSessionState:
     ingredient_names = [ing.name for ing in state.ingredients]
     equipment_names = [eq.name for eq in state.equipment]
 
-    # Create the agent prompt with recipe text properly quoted
-    recipe_text_escaped = state.raw_text.replace('"', '\\"').replace("'", "\\'")
+    # Create the agent prompt with pre-identified basic actions
+    basic_actions_info = [
+        {"verb": ba.verb, "sentence": ba.sentence, "sentence_index": ba.sentence_index}
+        for ba in state.basic_actions
+    ]
 
     agent_prompt = f"""
-You are a recipe analysis expert. Your task is to identify actions in a recipe and link them to specific ingredients and equipment.
+You are a recipe analysis expert. Your task is to link pre-identified cooking verbs to specific ingredients and equipment.
 
 You have access to these tools:
-- extract_verbs: Find all verbs in the recipe text with their sentence context
 - find_ingredients_in_sentence: Find ingredient names in a single sentence
 - find_equipment_in_sentence: Find equipment names in a single sentence
 - filter_valid_actions: Remove actions that have no ingredients or equipment
@@ -317,8 +435,8 @@ Available ingredients (with IDs):
 Available equipment (with IDs):
 {[{"name": eq.name, "id": eq.id} for eq in state.equipment]}
 
-Recipe text to analyze:
-"{recipe_text_escaped}"
+Pre-identified basic actions to process:
+{basic_actions_info}
 
 Your goal: Return a JSON object with this structure:
 {{
@@ -332,23 +450,21 @@ Your goal: Return a JSON object with this structure:
 }}
 
 Steps:
-1. Use extract_verbs to get all verbs with their sentence context
-2. For each cooking-relevant verb, use its sentence to find ingredients/equipment:
-   - find_ingredients_in_sentence(sentence=verb_sentence, ingredient_names=ingredient_list)
-   - find_equipment_in_sentence(sentence=verb_sentence, equipment_names=equipment_list)
-3. Create action objects linking verbs to the appropriate ingredient/equipment IDs
-4. Call filter_valid_actions(actions=validated_actions)
-5. OUTPUT FINAL JSON: {{"actions": [filtered_actions]}}
+1. For each basic action, use its sentence to find ingredients/equipment:
+   - find_ingredients_in_sentence(sentence=action_sentence, ingredient_names=ingredient_list)
+   - find_equipment_in_sentence(sentence=action_sentence, equipment_names=equipment_list)
+2. Create action objects linking verbs to the appropriate ingredient/equipment IDs
+3. Call filter_valid_actions(actions=validated_actions)
+4. OUTPUT FINAL JSON: {{"actions": [filtered_actions]}}
 
-Start by calling: extract_verbs(text="{recipe_text_escaped}")
-Then for each cooking verb, search only within its sentence context.
+Process each basic action systematically, matching ingredients and equipment within each sentence context.
 Use the filtering tools at the end instead of writing your own filtering code.
 """
 
     # Run the agent
     try:
         result = agent.run(agent_prompt)
-        state.workflow_step = "actions_parsing"
+        state.workflow_step = "dependencies_parsing"
 
         # Try to extract JSON from the result and convert to Action objects
         actions_data = None
@@ -395,9 +511,20 @@ Use the filtering tools at the end instead of writing your own filtering code.
                 continue
 
         state.actions = actions
-        state.workflow_step = "actions_parsed"
+        state.workflow_step = "dependencies_parsed"
         return state
 
     except Exception as e:
         msg.warn(f"Agent execution failed: {e}")
         return state
+
+
+# Backward compatibility alias
+def parse_actions(state: RecipeSessionState) -> RecipeSessionState:
+    """
+    Backward compatibility alias for parse_dependencies.
+
+    DEPRECATED: Use parse_dependencies instead.
+    """
+    msg.warn("parse_actions is deprecated, use parse_dependencies instead")
+    return parse_dependencies(state)

--- a/src/recipe_board/agents/prompts/__init__.py
+++ b/src/recipe_board/agents/prompts/__init__.py
@@ -60,7 +60,7 @@ equipment=[
 parse_equipment_prompt = f"""
 {briefing}
 
-Now, you will assist one such chef by parsing the equipment and ingredients from the recipe.
+Now, you will assist one such chef by parsing the equipment, ingredients, and cooking actions from the recipe.
 
 Return ONLY valid JSON with this exact structure. Do not include any other text, explanations, or markdown:
 
@@ -71,8 +71,13 @@ Return ONLY valid JSON with this exact structure. Do not include any other text,
   ],
   "ingredients": [
     {{"name": "flour", "amount": 3, "unit": "cup", "modifiers": "all-purpose"}},
-    {{"name": "salt", "amount": 1, "unit": "tsp", "modifiers": null}}
+    {{"name": "salt", "amount": 1, "unit": "tsp", "modifiers": null}},
+    {{"name": "olive oil", "amount": 0.5, "unit": "cup", "modifiers": null}}
   ],
+  "basic_actions": [
+    {{"verb": "mix", "sentence": "In large mixing bowl, combine 3 cups flour, 1 tsp salt, 1 packet yeast, and 1 cup warm water.", "sentence_index": 0}},
+    {{"verb": "combine", "sentence": "In large mixing bowl, combine 3 cups flour, 1 tsp salt, 1 packet yeast, and 1 cup warm water.", "sentence_index": 0}}
+  ]
 }}
 
 IMPORTANT:
@@ -80,6 +85,9 @@ IMPORTANT:
 * Do not include markdown code blocks, explanations, or any other text
 * All string values must be properly quoted
 * Use null for empty modifiers, not empty strings
+* For amounts, use decimal numbers (e.g., 0.5, 0.25, 0.33) NOT fractions (e.g., 1/2, 1/4, 1/3)
+* For basic_actions, extract cooking verbs (mix, combine, bake, etc.) with their full sentence context
+* sentence_index starts at 0 for the first sentence
 
 Recipe to parse:
 """

--- a/src/recipe_board/core/recipe.py
+++ b/src/recipe_board/core/recipe.py
@@ -30,6 +30,14 @@ class Equipment(BaseModel):
     modifiers: Optional[str]
 
 
+class BasicAction(BaseModel):
+    """Represents a cooking verb identified in the first parsing pass."""
+
+    verb: str
+    sentence: str
+    sentence_index: int  # For reference back to original text
+
+
 class Action(BaseModel):
     id: str = Field(default_factory=lambda: str(uuid.uuid4()))
     name: str

--- a/src/recipe_board/core/state.py
+++ b/src/recipe_board/core/state.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass, field
 from typing import List, Dict, Any
-from recipe_board.core.recipe import Ingredient, Equipment, Action
+from recipe_board.core.recipe import Ingredient, Equipment, Action, BasicAction
 
 
 @dataclass
@@ -16,6 +16,7 @@ class RecipeSessionState:
     raw_text: str = ""
     ingredients: List[Ingredient] = field(default_factory=list)
     equipment: List[Equipment] = field(default_factory=list)
+    basic_actions: List[BasicAction] = field(default_factory=list)
     actions: List[Action] = field(default_factory=list)
     workflow_step: str = "initial"
 
@@ -25,6 +26,7 @@ class RecipeSessionState:
             "raw_text": self.raw_text,
             "ingredients": [ing.model_dump() for ing in self.ingredients],
             "equipment": [eq.model_dump() for eq in self.equipment],
+            "basic_actions": [ba.model_dump() for ba in self.basic_actions],
             "actions": [action.model_dump() for action in self.actions],
             "workflow_step": self.workflow_step,
         }
@@ -38,6 +40,7 @@ class RecipeSessionState:
         self.raw_text = ""
         self.ingredients = []
         self.equipment = []
+        self.basic_actions = []
         self.actions = []
         self.workflow_step = "initial"
 
@@ -73,6 +76,17 @@ class RecipeSessionState:
             if eq.required:
                 display += " [required]"
             formatted.append(display)
+
+        return "\n".join(f"- {item}" for item in formatted)
+
+    def format_basic_actions_for_display(self) -> str:
+        """Format basic actions list for UI display."""
+        if not self.basic_actions:
+            return "No basic actions parsed yet."
+
+        formatted = []
+        for ba in self.basic_actions:
+            formatted.append(f"'{ba.verb}' in: {ba.sentence[:80]}...")
 
         return "\n".join(f"- {item}" for item in formatted)
 

--- a/test/test_json_extraction.py
+++ b/test/test_json_extraction.py
@@ -1,0 +1,157 @@
+"""Unit tests for JSON extraction and cleaning logic."""
+
+import pytest
+import json
+from recipe_board.agents.models import _extract_json_from_response
+
+
+class TestJSONExtraction:
+    """Test suite for JSON extraction from LLM responses."""
+
+    def test_extract_json_from_standard_code_block(self):
+        """Test extraction from standard ```json code blocks."""
+        response = '''```json
+{
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [{"name": "flour", "amount": 2}],
+  "basic_actions": []
+}
+```'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+        assert "equipment" in parsed
+        assert "ingredients" in parsed
+        assert "basic_actions" in parsed
+
+    def test_extract_json_with_text_before_code_block(self):
+        """Test extraction when there's text before the code block."""
+        response = '''{Create Answer} ```json
+{
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [{"name": "flour", "amount": 2}],
+  "basic_actions": []
+}
+```'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+        assert "equipment" in parsed
+        assert "ingredients" in parsed
+
+    def test_extract_json_with_text_after_code_block(self):
+        """Test extraction when there's text after the code block."""
+        response = '''```json
+{
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [{"name": "flour", "amount": 2}],
+  "basic_actions": []
+}
+``` Hope this helps!'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+        assert "equipment" in parsed
+
+    def test_extract_json_with_text_before_and_after(self):
+        """Test extraction with text both before and after code block."""
+        response = '''Here's your parsed recipe: ```json
+{
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [{"name": "flour", "amount": 0.5}],
+  "basic_actions": [{"verb": "mix", "sentence": "Mix ingredients.", "sentence_index": 0}]
+}
+``` Let me know if you need anything else!'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+        assert len(parsed["ingredients"]) == 1
+        assert parsed["ingredients"][0]["amount"] == 0.5
+
+    def test_extract_json_from_generic_code_block(self):
+        """Test extraction from generic ``` code blocks without 'json' specifier."""
+        response = '''```
+{
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [{"name": "flour", "amount": 2}],
+  "basic_actions": []
+}
+```'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+
+    def test_extract_json_object_without_code_blocks(self):
+        """Test extraction of JSON object when no code blocks are present."""
+        response = '''The parsed recipe is: {
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [{"name": "flour", "amount": 2}],
+  "basic_actions": []
+} and that's it!'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+
+    def test_extract_json_handles_nested_braces(self):
+        """Test that extraction works with nested JSON structures."""
+        response = '''{Some text} ```json
+{
+  "equipment": [{"name": "oven", "required": true, "details": {"temp": "350F"}}],
+  "ingredients": [{"name": "flour", "amount": 2}],
+  "basic_actions": []
+}
+```'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert isinstance(parsed, dict)
+        assert "details" in parsed["equipment"][0]
+
+    def test_extract_json_no_valid_json_found(self):
+        """Test behavior when no valid JSON is found."""
+        response = "This is just plain text with no JSON structure at all."
+
+        result = _extract_json_from_response(response)
+
+        # Should return the original response when no JSON is found
+        assert result == response
+
+    def test_extract_json_empty_response(self):
+        """Test handling of empty or whitespace-only responses."""
+        assert _extract_json_from_response("") == ""
+        assert _extract_json_from_response("   ") == ""
+        assert _extract_json_from_response("\n\t  \n") == ""
+
+    def test_extract_json_with_fractions_in_amounts(self):
+        """Test that we can handle responses with decimal amounts."""
+        response = '''```json
+{
+  "equipment": [{"name": "oven", "required": true}],
+  "ingredients": [
+    {"name": "flour", "amount": 2.5, "unit": "cups"},
+    {"name": "oil", "amount": 0.5, "unit": "cup"},
+    {"name": "sugar", "amount": 0.25, "unit": "cup"}
+  ],
+  "basic_actions": []
+}
+```'''
+
+        result = _extract_json_from_response(response)
+        parsed = json.loads(result)
+
+        assert parsed["ingredients"][0]["amount"] == 2.5
+        assert parsed["ingredients"][1]["amount"] == 0.5
+        assert parsed["ingredients"][2]["amount"] == 0.25

--- a/test/test_state.py
+++ b/test/test_state.py
@@ -1,5 +1,5 @@
 from recipe_board.core.state import RecipeSessionState
-from recipe_board.core.recipe import Ingredient, Equipment, Action
+from recipe_board.core.recipe import Ingredient, Equipment, Action, BasicAction
 
 
 class TestRecipeSessionState:
@@ -84,6 +84,7 @@ class TestRecipeSessionState:
             "raw_text": "",
             "ingredients": [],
             "equipment": [],
+            "basic_actions": [],
             "actions": [],
             "workflow_step": "initial"
         }
@@ -99,6 +100,9 @@ class TestRecipeSessionState:
         state.equipment = [
             Equipment(name="mixing bowl", required=True, modifiers="large")
         ]
+        state.basic_actions = [
+            BasicAction(verb="mix", sentence="Mix flour in bowl.", sentence_index=0)
+        ]
         state.actions = [
             Action(name="mix", ingredient_ids=["ing1"], equipment_ids="eq1")
         ]
@@ -110,12 +114,14 @@ class TestRecipeSessionState:
         assert "raw_text" in result
         assert "ingredients" in result
         assert "equipment" in result
+        assert "basic_actions" in result
         assert "actions" in result
         assert "workflow_step" in result
 
         assert result["raw_text"] == "Test recipe"
         assert result["workflow_step"] == "parsed"
         assert len(result["ingredients"]) == 1
+        assert len(result["basic_actions"]) == 1
         assert len(result["equipment"]) == 1
         assert len(result["actions"]) == 1
 


### PR DESCRIPTION
Change to _identifying_ the Actions in the first parsing pass, so that the second pass is more focused. The _dependencies/relationships_ continue to be identified in the second pass, as before.

The split allows us leverage the powerful flexibility of the plain LLM request/"first pass", which is free to leverage its semantic knowledge to identify the actions, and is not constrained to the tools we provide as the agent is. Conversely, the tools tools we implement for the agent don't need to be as good at semantics.