### PR TITLE
chore: add syncing to HuggingFace Space

### DIFF
--- a/.github/workflows/hf-sync.yml
+++ b/.github/workflows/hf-sync.yml
@@ -1,0 +1,17 @@
+name: Sync to Hugging Face hub
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+jobs:
+  sync-to-hub:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          lfs: true
+      - name: Push to hub
+        env:
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+        run: git push https://AndrewADev:$HF_TOKEN@huggingface.co/spaces/AndrewADev/recipe-board main

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: Test
+name: PR Checks
 
 on:
   pull_request:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+---
+title: Recipe Board
+emoji: 📉
+colorFrom: yellow
+colorTo: purple
+sdk: gradio
+sdk_version: 5.0.0
+app_file: src/recipe_board/main.py
+pinned: false
+---
 # RecipeBoard
 
 A tool to help hobbyist chefs discover and better understand the implicit dependencies in recipes they’d like to cook or bake.


### PR DESCRIPTION
Add a workflow to sync on push to main, resulting in a deploy to the linked HF Space.

Also add check for large files (per HF setup docs, here: https://huggingface.co/docs/hub/en/spaces-github-actions )

Finally, add HF meta, which is needed by the space.
