### PR TITLE
test: add timeout to UI smoke test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dev = [
     "pytest>=8.0.0",
     "pytest-cov>=6.1.1",
     "pytest-dotenv>=0.5.2",
+    "pytest-timeout>=2.4.0",
 ]
 
 [tool.uv]

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -20,7 +20,7 @@ def gradio_app():
     app.launch(
         server_port=test_port,
         share=False,
-        quiet=True,
+        debug=True,
         prevent_thread_lock=True  # Returns immediately, doesn't block
     )
 

--- a/test/test_ui_smoke.py
+++ b/test/test_ui_smoke.py
@@ -1,7 +1,9 @@
 
 from conftest import test_port
+import pytest
 
 
+@pytest.mark.timeout(20)
 def test_app_starts(gradio_app):
     """Smoke test - just verify the app is running"""
     import requests

--- a/uv.lock
+++ b/uv.lock
@@ -914,6 +914,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -993,6 +1005,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-dotenv" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -1016,6 +1029,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.1.1" },
     { name = "pytest-dotenv", specifier = ">=0.5.2" },
+    { name = "pytest-timeout", specifier = ">=2.4.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
Set an upper limit for the UI smoke test, to log a failure if it hasn't started in a reasonable amount of time.
