### PR TITLE
fix: remove empty samples option

### DIFF
--- a/data/claudes-omelette.md
+++ b/data/claudes-omelette.md
@@ -1,0 +1,23 @@
+# Classic French Omelette
+
+A classic French omelette recipe that's simple yet elegant:
+
+## Ingredients:
+
+* 3 fresh eggs
+* 2-3 tablespoons butter
+* Salt and white pepper to taste
+* Optional: fresh herbs like chives, parsley, or tarragon
+
+## Method:
+
+1. Crack eggs into a bowl and whisk vigorously until completely smooth - no streaks of white should remain
+2. Season lightly with salt and a pinch of white pepper
+3. Heat a non-stick or well-seasoned pan over medium-low heat
+4. Add butter and let it foam, then swirl to coat the pan
+5. Pour in the eggs and immediately start stirring gently with a fork or spatula, keeping the eggs moving
+6. As curds form, tilt the pan and let uncooked egg flow underneath
+7. When the eggs are almost set but still slightly creamy on top (about 2-3 minutes), stop stirring
+8. If using herbs, sprinkle them on one half
+9. Fold the omelette in half using your spatula and slide onto a plate
+10. The key is gentle heat and constant movement until the very end. The omelette should be pale yellow, creamy, and never browned. The whole process takes just a few minutes, so have your plate ready!

--- a/src/recipe_board/core/sample_recipes.py
+++ b/src/recipe_board/core/sample_recipes.py
@@ -91,7 +91,8 @@ def get_sample_recipe_choices(include_empty: bool = True) -> list:
         List of recipe titles suitable for dropdown choices.
     """
     recipes = load_sample_recipes()
-    choices = list(recipes.keys())
+    # Filter out empty or whitespace-only titles
+    choices = [title for title in recipes.keys() if title and title.strip()]
 
     if include_empty:
         choices = [""] + choices

--- a/src/recipe_board/gradio_ui.py
+++ b/src/recipe_board/gradio_ui.py
@@ -32,7 +32,8 @@ def create_parser_tab(session_state, main_tabs):
 
         # Load sample recipes
         sample_recipes = load_sample_recipes()
-        recipe_choices = get_sample_recipe_choices()
+        recipe_choices = get_sample_recipe_choices(include_empty=False)
+        recipe_choices = ["-- Select a recipe --"] + recipe_choices
 
         with gr.Row():
             with gr.Column(scale=1):
@@ -43,7 +44,7 @@ def create_parser_tab(session_state, main_tabs):
                     sample_dropdown = gr.Dropdown(
                         choices=recipe_choices,
                         label="Choose a sample recipe",
-                        value="",
+                        value="-- Select a recipe --",
                         interactive=True,
                     )
 
@@ -322,7 +323,7 @@ def create_parser_tab(session_state, main_tabs):
 
         def handle_sample_selection(selected_recipe):
             """Handle sample recipe dropdown selection."""
-            if not selected_recipe:
+            if not selected_recipe or selected_recipe == "-- Select a recipe --":
                 return (
                     gr.update(visible=False),  # Hide preview
                     "",  # Clear preview text


### PR DESCRIPTION
Replace empty option in samples dropdown with a default message:

![image](https://github.com/user-attachments/assets/06597ca6-13e1-48b2-89ac-b4ccfef7d8a2)


Add an additional sample to the dropdown.
